### PR TITLE
Remove defaults channel

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,4 @@
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - black=23.3.0


### PR DESCRIPTION
This is causing issues when the defaults channel isn't configured. For all of our other pre commit mirrors, we don't have the defaults channel either.

ping @euklid321 